### PR TITLE
fix: validate middleware configs and panic on unsafe zero values

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -77,6 +77,10 @@ var safeMethods = map[string]bool{
 // CSRFProtect returns middleware that implements double-submit cookie CSRF
 // protection. The CSRF token is available to handlers via [GetToken].
 func CSRFProtect(cfg CSRFConfig) func(http.Handler) http.Handler {
+	if len(cfg.Key) < 32 {
+		panic("dorman: CSRFConfig.Key must be at least 32 bytes")
+	}
+
 	// Apply defaults.
 	if cfg.FieldName == "" {
 		cfg.FieldName = "csrf_token"

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -44,6 +44,26 @@ func extractCookie(rec *httptest.ResponseRecorder, name string) *http.Cookie {
 	return nil
 }
 
+// --- CSRFProtect validation tests ---
+
+func TestCSRFProtect_PanicsOnEmptyKey(t *testing.T) {
+	require.PanicsWithValue(t, "dorman: CSRFConfig.Key must be at least 32 bytes", func() {
+		CSRFProtect(CSRFConfig{})
+	})
+}
+
+func TestCSRFProtect_PanicsOnShortKey(t *testing.T) {
+	require.PanicsWithValue(t, "dorman: CSRFConfig.Key must be at least 32 bytes", func() {
+		CSRFProtect(CSRFConfig{Key: []byte("short")})
+	})
+}
+
+func TestCSRFProtect_AcceptsValidKey(t *testing.T) {
+	require.NotPanics(t, func() {
+		CSRFProtect(minimalCfg())
+	})
+}
+
 // TestGET_SetsCookieAndContextToken verifies that a GET request causes the
 // middleware to issue a CSRF cookie and store the token on the context.
 func TestGET_SetsCookieAndContextToken(t *testing.T) {

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -58,6 +58,21 @@ type rateLimitStore struct {
 // requests per time window. Requests that exceed the limit receive a 429
 // response with a Retry-After header indicating when the window resets.
 func RateLimit(cfg RateLimitConfig) func(http.Handler) http.Handler {
+	if cfg.Requests <= 0 {
+		panic("dorman: RateLimitConfig.Requests must be greater than zero")
+	}
+	if cfg.Window <= 0 {
+		panic("dorman: RateLimitConfig.Window must be greater than zero")
+	}
+	for path, rule := range cfg.PerPath {
+		if rule.Requests <= 0 {
+			panic(fmt.Sprintf("dorman: RateLimitConfig.PerPath[%q].Requests must be greater than zero", path))
+		}
+		if rule.Window <= 0 {
+			panic(fmt.Sprintf("dorman: RateLimitConfig.PerPath[%q].Window must be greater than zero", path))
+		}
+	}
+
 	keyFunc := cfg.KeyFunc
 	if keyFunc == nil {
 		keyFunc = IPKey
@@ -228,6 +243,13 @@ func (bw *bruteForceWriter) WriteHeader(code int) {
 // handler's response status is inspected via a wrapped ResponseWriter. Once
 // blocked, the key is rejected with a 429 response until the Cooldown expires.
 func BruteForceProtect(cfg BruteForceConfig) func(http.Handler) http.Handler {
+	if cfg.MaxAttempts <= 0 {
+		panic("dorman: BruteForceConfig.MaxAttempts must be greater than zero")
+	}
+	if cfg.Cooldown <= 0 {
+		panic("dorman: BruteForceConfig.Cooldown must be greater than zero")
+	}
+
 	keyFunc := cfg.KeyFunc
 	if keyFunc == nil {
 		keyFunc = IPKey

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -30,6 +30,58 @@ func fakeNow() (func() time.Time, func(time.Duration)) {
 		func(d time.Duration) { now = now.Add(d) }
 }
 
+// --- RateLimit validation tests ---
+
+func TestRateLimit_PanicsOnZeroRequests(t *testing.T) {
+	require.PanicsWithValue(t, "dorman: RateLimitConfig.Requests must be greater than zero", func() {
+		RateLimit(RateLimitConfig{Requests: 0, Window: time.Minute})
+	})
+}
+
+func TestRateLimit_PanicsOnZeroWindow(t *testing.T) {
+	require.PanicsWithValue(t, "dorman: RateLimitConfig.Window must be greater than zero", func() {
+		RateLimit(RateLimitConfig{Requests: 5, Window: 0})
+	})
+}
+
+func TestRateLimit_PanicsOnInvalidPerPathRequests(t *testing.T) {
+	require.Panics(t, func() {
+		RateLimit(RateLimitConfig{
+			Requests: 5,
+			Window:   time.Minute,
+			PerPath: map[string]RateRule{
+				"/api": {Requests: 0, Window: time.Minute},
+			},
+		})
+	})
+}
+
+func TestRateLimit_PanicsOnInvalidPerPathWindow(t *testing.T) {
+	require.Panics(t, func() {
+		RateLimit(RateLimitConfig{
+			Requests: 5,
+			Window:   time.Minute,
+			PerPath: map[string]RateRule{
+				"/api": {Requests: 10, Window: 0},
+			},
+		})
+	})
+}
+
+// --- BruteForceProtect validation tests ---
+
+func TestBruteForceProtect_PanicsOnZeroMaxAttempts(t *testing.T) {
+	require.PanicsWithValue(t, "dorman: BruteForceConfig.MaxAttempts must be greater than zero", func() {
+		BruteForceProtect(BruteForceConfig{MaxAttempts: 0, Cooldown: time.Minute})
+	})
+}
+
+func TestBruteForceProtect_PanicsOnZeroCooldown(t *testing.T) {
+	require.PanicsWithValue(t, "dorman: BruteForceConfig.Cooldown must be greater than zero", func() {
+		BruteForceProtect(BruteForceConfig{MaxAttempts: 5, Cooldown: 0})
+	})
+}
+
 // --- RateLimit tests ---
 
 func TestRateLimit_UnderLimit_Passes(t *testing.T) {


### PR DESCRIPTION
## Summary

- `CSRFProtect` now panics if `Key` is shorter than 32 bytes
- `RateLimit` now panics if `Requests` or `Window` is zero, including per-path rules in `PerPath`
- `BruteForceProtect` now panics if `MaxAttempts` or `Cooldown` is zero
- Added tests using `require.PanicsWithValue` and `require.Panics` for all validation cases

These are programmer errors caught at init time, so panicking is appropriate (similar to `regexp.MustCompile`).

Closes #3

## Test plan

- [x] `go test ./...` passes
- [x] CSRF: panics on empty key, short key; accepts 32+ byte key
- [x] RateLimit: panics on zero Requests, zero Window, invalid PerPath rules
- [x] BruteForceProtect: panics on zero MaxAttempts, zero Cooldown