### PR TITLE
fix: unify RequireAllRoles to accept AuthOption

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -135,7 +135,8 @@ func RequireRole(provider IdentityProvider, role string, opts ...AuthOption) fun
 // RequireAllRoles returns middleware that requires the identity to have all of
 // the given roles. Unauthenticated requests receive 401; authenticated requests
 // missing any role receive 403.
-func RequireAllRoles(provider IdentityProvider, roles ...string) func(http.Handler) http.Handler {
+func RequireAllRoles(provider IdentityProvider, roles []string, opts ...AuthOption) func(http.Handler) http.Handler {
+	cfg := buildAuthConfig(opts)
 	want := make(map[string]struct{}, len(roles))
 	for _, r := range roles {
 		want[r] = struct{}{}
@@ -144,7 +145,7 @@ func RequireAllRoles(provider IdentityProvider, roles ...string) func(http.Handl
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			id, err := provider.GetIdentity(r)
 			if err != nil || id == nil {
-				http.Error(w, "", http.StatusUnauthorized)
+				authFail(w, r, ErrUnauthorized, http.StatusUnauthorized, cfg)
 				return
 			}
 			have := make(map[string]struct{}, len(id.Roles()))
@@ -153,7 +154,7 @@ func RequireAllRoles(provider IdentityProvider, roles ...string) func(http.Handl
 			}
 			for needed := range want {
 				if _, ok := have[needed]; !ok {
-					http.Error(w, "", http.StatusForbidden)
+					authFail(w, r, ErrForbidden, http.StatusForbidden, cfg)
 					return
 				}
 			}

--- a/auth_test.go
+++ b/auth_test.go
@@ -379,7 +379,7 @@ func TestRequireAllRoles(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mw := RequireAllRoles(tt.provider, tt.roles...)
+			mw := RequireAllRoles(tt.provider, tt.roles)
 			handler := mw(ok)
 
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -389,6 +389,49 @@ func TestRequireAllRoles(t *testing.T) {
 			require.Equal(t, tt.wantCode, rec.Code)
 		})
 	}
+}
+
+func TestAuthErrorHandler_RequireAllRoles_Forbidden(t *testing.T) {
+	id := SimpleIdentity{ID: "user-1", RoleList: []string{"viewer"}}
+	provider := &staticProvider{identity: id}
+
+	var gotErr error
+	handler := RequireAllRoles(provider, []string{"admin", "editor"}, AuthErrorHandler(func(w http.ResponseWriter, r *http.Request, err error) {
+		gotErr = err
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("missing required role"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, req)
+
+	require.ErrorIs(t, gotErr, ErrForbidden)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Equal(t, "missing required role", rec.Body.String())
+}
+
+func TestAuthErrorHandler_RequireAllRoles_Unauthorized(t *testing.T) {
+	provider := &staticProvider{err: ErrNoIdentity}
+
+	var gotErr error
+	handler := RequireAllRoles(provider, []string{"admin"}, AuthErrorHandler(func(w http.ResponseWriter, r *http.Request, err error) {
+		gotErr = err
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("login required"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, req)
+
+	require.ErrorIs(t, gotErr, ErrUnauthorized)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Equal(t, "login required", rec.Body.String())
 }
 
 // Compile-time interface checks.


### PR DESCRIPTION
## Summary

- Changed `RequireAllRoles` signature from `(provider, roles ...string)` to `(provider, roles []string, opts ...AuthOption)` to match `RequireAnyRole`'s pattern
- Replaced bare `http.Error` calls with `buildAuthConfig`/`authFail` so custom error handlers work consistently across all auth middleware
- Added tests for custom error handling on `RequireAllRoles` (both 401 and 403 cases)

**BREAKING CHANGE**: `RequireAllRoles` signature changed — callers using `RequireAllRoles(p, "role1", "role2")` must change to `RequireAllRoles(p, []string{"role1", "role2"})`.

Closes #5

## Test plan

- [x] All existing tests updated and passing
- [x] New test: `TestAuthErrorHandler_RequireAllRoles_Forbidden` — verifies custom error handler receives `ErrForbidden` when roles are missing
- [x] New test: `TestAuthErrorHandler_RequireAllRoles_Unauthorized` — verifies custom error handler receives `ErrUnauthorized` when no identity is present