### PR TITLE
fix: preserve optional ResponseWriter interfaces in custom wrappers

### DIFF
--- a/body.go
+++ b/body.go
@@ -1,7 +1,10 @@
 package dorman
 
 import (
+	"bufio"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"sync"
 )
@@ -46,6 +49,27 @@ func (m *maxBodyWriter) Write(b []byte) (int, error) {
 		return io.Discard.Write(b)
 	}
 	return m.ResponseWriter.Write(b)
+}
+
+// Unwrap returns the underlying ResponseWriter so that [http.NewResponseController]
+// can access optional interfaces on the original writer.
+func (m *maxBodyWriter) Unwrap() http.ResponseWriter {
+	return m.ResponseWriter
+}
+
+// Flush delegates to the underlying ResponseWriter if it implements [http.Flusher].
+func (m *maxBodyWriter) Flush() {
+	if f, ok := m.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack delegates to the underlying ResponseWriter if it implements [http.Hijacker].
+func (m *maxBodyWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := m.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, fmt.Errorf("dorman: underlying ResponseWriter does not implement http.Hijacker")
 }
 
 // MaxRequestBody returns middleware that limits request body size using

--- a/body_test.go
+++ b/body_test.go
@@ -10,6 +10,71 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMaxBodyWriter_Unwrap(t *testing.T) {
+	inner := httptest.NewRecorder()
+	w := &maxBodyWriter{ResponseWriter: inner}
+	require.Equal(t, http.ResponseWriter(inner), w.Unwrap())
+}
+
+func TestMaxBodyWriter_Flush_Delegates(t *testing.T) {
+	inner := &flusherHijackerRecorder{ResponseWriter: httptest.NewRecorder()}
+	w := &maxBodyWriter{ResponseWriter: inner}
+	w.Flush()
+	require.True(t, inner.flushed)
+}
+
+func TestMaxBodyWriter_Flush_NoopWhenNotSupported(t *testing.T) {
+	inner := newPlainResponseWriter()
+	w := &maxBodyWriter{ResponseWriter: inner}
+	// Should not panic when underlying writer does not implement Flusher.
+	w.Flush()
+}
+
+func TestMaxBodyWriter_Hijack_Delegates(t *testing.T) {
+	inner := &flusherHijackerRecorder{ResponseWriter: httptest.NewRecorder()}
+	w := &maxBodyWriter{ResponseWriter: inner}
+	_, _, err := w.Hijack()
+	require.NoError(t, err)
+	require.True(t, inner.hijacked)
+}
+
+func TestMaxBodyWriter_Hijack_ErrorWhenNotSupported(t *testing.T) {
+	inner := newPlainResponseWriter()
+	w := &maxBodyWriter{ResponseWriter: inner}
+	_, _, err := w.Hijack()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "http.Hijacker")
+}
+
+func TestMaxBodyWriter_InterfacePreservation_ThroughMiddleware(t *testing.T) {
+	inner := &flusherHijackerRecorder{ResponseWriter: httptest.NewRecorder()}
+
+	var capturedWriter http.ResponseWriter
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedWriter = w
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := MaxRequestBody(MaxBodyConfig{
+		Default:      1024,
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request) {},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("hello"))
+	mw(handler).ServeHTTP(inner, req)
+
+	// The captured writer should support Flusher and Hijacker via delegation.
+	_, ok := capturedWriter.(http.Flusher)
+	require.True(t, ok, "maxBodyWriter should implement http.Flusher")
+
+	_, ok = capturedWriter.(http.Hijacker)
+	require.True(t, ok, "maxBodyWriter should implement http.Hijacker")
+
+	// NewResponseController should be able to reach the underlying writer.
+	rc := http.NewResponseController(capturedWriter)
+	require.NotNil(t, rc)
+}
+
 // echoBodyHandler reads the full request body and writes it back. If the read
 // fails (e.g. MaxBytesReader limit hit), it writes a 413 response.
 func echoBodyHandler() http.Handler {

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,6 +1,7 @@
 package dorman
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"net"
@@ -221,6 +222,27 @@ func (bw *bruteForceWriter) WriteHeader(code int) {
 		}
 	})
 	bw.ResponseWriter.WriteHeader(code)
+}
+
+// Unwrap returns the underlying ResponseWriter so that [http.NewResponseController]
+// can access optional interfaces on the original writer.
+func (bw *bruteForceWriter) Unwrap() http.ResponseWriter {
+	return bw.ResponseWriter
+}
+
+// Flush delegates to the underlying ResponseWriter if it implements [http.Flusher].
+func (bw *bruteForceWriter) Flush() {
+	if f, ok := bw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack delegates to the underlying ResponseWriter if it implements [http.Hijacker].
+func (bw *bruteForceWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := bw.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, fmt.Errorf("dorman: underlying ResponseWriter does not implement http.Hijacker")
 }
 
 // BruteForceProtect returns middleware that tracks failed response status codes

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -3,11 +3,104 @@ package dorman
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestBruteForceWriter_Unwrap(t *testing.T) {
+	inner := httptest.NewRecorder()
+	w := &bruteForceWriter{ResponseWriter: inner}
+	require.Equal(t, http.ResponseWriter(inner), w.Unwrap())
+}
+
+func TestBruteForceWriter_Flush_Delegates(t *testing.T) {
+	inner := &flusherHijackerRecorder{ResponseWriter: httptest.NewRecorder()}
+	w := &bruteForceWriter{ResponseWriter: inner}
+	w.Flush()
+	require.True(t, inner.flushed)
+}
+
+func TestBruteForceWriter_Flush_NoopWhenNotSupported(t *testing.T) {
+	inner := newPlainResponseWriter()
+	w := &bruteForceWriter{ResponseWriter: inner}
+	w.Flush()
+}
+
+func TestBruteForceWriter_Hijack_Delegates(t *testing.T) {
+	inner := &flusherHijackerRecorder{ResponseWriter: httptest.NewRecorder()}
+	w := &bruteForceWriter{ResponseWriter: inner}
+	_, _, err := w.Hijack()
+	require.NoError(t, err)
+	require.True(t, inner.hijacked)
+}
+
+func TestBruteForceWriter_Hijack_ErrorWhenNotSupported(t *testing.T) {
+	inner := newPlainResponseWriter()
+	w := &bruteForceWriter{ResponseWriter: inner}
+	_, _, err := w.Hijack()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "http.Hijacker")
+}
+
+func TestBruteForceWriter_InterfacePreservation_ThroughMiddleware(t *testing.T) {
+	inner := &flusherHijackerRecorder{ResponseWriter: httptest.NewRecorder()}
+
+	var capturedWriter http.ResponseWriter
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedWriter = w
+		w.WriteHeader(http.StatusOK)
+	})
+
+	store := &bruteForceStore{
+		entries:  make(map[string]*bruteForceEntry),
+		nowFunc:  time.Now,
+		max:      5,
+		cooldown: time.Minute,
+	}
+	failureSet := map[int]bool{http.StatusUnauthorized: true}
+	mw := buildBruteForceHandler(BruteForceConfig{MaxAttempts: 5, Cooldown: time.Minute}, store, failureSet, IPKey)
+
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	mw(handler).ServeHTTP(inner, req)
+
+	_, ok := capturedWriter.(http.Flusher)
+	require.True(t, ok, "bruteForceWriter should implement http.Flusher")
+
+	_, ok = capturedWriter.(http.Hijacker)
+	require.True(t, ok, "bruteForceWriter should implement http.Hijacker")
+
+	rc := http.NewResponseController(capturedWriter)
+	require.NotNil(t, rc)
+}
+
+// Verify bruteForceWriter still tracks failures correctly with the new methods.
+func TestBruteForceWriter_StillTracksFailures(t *testing.T) {
+	store := &bruteForceStore{
+		entries:  make(map[string]*bruteForceEntry),
+		nowFunc:  time.Now,
+		max:      2,
+		cooldown: time.Minute,
+	}
+	w := &bruteForceWriter{
+		ResponseWriter: httptest.NewRecorder(),
+		store:          store,
+		key:            "testkey",
+		failureSet:     map[int]bool{401: true},
+		once:           sync.Once{},
+	}
+	w.WriteHeader(401)
+
+	store.mu.Lock()
+	entry := store.entries["testkey"]
+	store.mu.Unlock()
+
+	require.NotNil(t, entry)
+	require.Equal(t, 1, entry.count)
+}
 
 // okHandler writes a 200 response.
 func okHandler() http.Handler {

--- a/responsewriter_test.go
+++ b/responsewriter_test.go
@@ -1,0 +1,40 @@
+package dorman
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+)
+
+// flusherHijackerRecorder is an httptest.ResponseRecorder-like type that also
+// implements http.Flusher and http.Hijacker for testing interface forwarding.
+type flusherHijackerRecorder struct {
+	http.ResponseWriter
+	flushed  bool
+	hijacked bool
+}
+
+func (f *flusherHijackerRecorder) Flush() {
+	f.flushed = true
+}
+
+func (f *flusherHijackerRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	f.hijacked = true
+	return nil, nil, nil
+}
+
+// plainResponseWriter is a minimal ResponseWriter that does NOT implement
+// http.Flusher or http.Hijacker. Used to test that delegation gracefully
+// handles missing optional interfaces.
+type plainResponseWriter struct {
+	code   int
+	header http.Header
+}
+
+func newPlainResponseWriter() *plainResponseWriter {
+	return &plainResponseWriter{header: make(http.Header)}
+}
+
+func (p *plainResponseWriter) Header() http.Header         { return p.header }
+func (p *plainResponseWriter) Write(b []byte) (int, error)  { return len(b), nil }
+func (p *plainResponseWriter) WriteHeader(code int)         { p.code = code }


### PR DESCRIPTION
## Summary

- Add `Unwrap()`, `Flush()`, and `Hijack()` methods to `maxBodyWriter` (body.go) and `bruteForceWriter` (ratelimit.go)
- `Unwrap()` enables `http.NewResponseController` (Go 1.20+) to reach the underlying writer's optional interfaces
- `Flush()` and `Hijack()` provide direct interface delegation for code that type-asserts `http.Flusher` or `http.Hijacker`
- When the underlying writer does not support the interface, `Flush()` is a no-op and `Hijack()` returns a descriptive error

## Test plan

- [x] `TestMaxBodyWriter_Unwrap` / `TestBruteForceWriter_Unwrap` — verify Unwrap returns the inner writer
- [x] `Test*_Flush_Delegates` — verify Flush calls through to the underlying Flusher
- [x] `Test*_Flush_NoopWhenNotSupported` — verify no panic when underlying writer lacks Flusher
- [x] `Test*_Hijack_Delegates` — verify Hijack calls through to the underlying Hijacker
- [x] `Test*_Hijack_ErrorWhenNotSupported` — verify error when underlying writer lacks Hijacker
- [x] `Test*_InterfacePreservation_ThroughMiddleware` — verify wrappers satisfy Flusher/Hijacker when used through the actual middleware
- [x] `TestBruteForceWriter_StillTracksFailures` — verify existing failure tracking is unaffected
- [x] All existing tests pass (`go test ./...`)

Fixes #4