### PR TITLE
test: add edge-case tests for middleware gaps

### DIFF
--- a/csrf_test.go
+++ b/csrf_test.go
@@ -579,6 +579,88 @@ func TestOriginValidation_RefererFallback(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, postRec2.Code)
 }
 
+// TestPOST_EmptyTokenHeader_Returns403 verifies that submitting an empty CSRF
+// token in the header is rejected with 403.
+func TestPOST_EmptyTokenHeader_Returns403(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CSRFProtect(minimalCfg())(inner)
+
+	getRec := doRequest(t, handler, http.MethodGet, "/", nil)
+	nonceCookie := extractCookie(getRec, "_csrf")
+	require.NotNil(t, nonceCookie)
+
+	// Submit empty token via header.
+	postRec := doRequest(t, handler, http.MethodPost, "/", func(r *http.Request) {
+		r.AddCookie(nonceCookie)
+		r.Header.Set("X-CSRF-Token", "")
+	})
+	require.Equal(t, http.StatusForbidden, postRec.Code)
+}
+
+// TestPOST_EmptyTokenFormField_Returns403 verifies that submitting an empty
+// CSRF token via form field is rejected with 403.
+func TestPOST_EmptyTokenFormField_Returns403(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CSRFProtect(minimalCfg())(inner)
+
+	getRec := doRequest(t, handler, http.MethodGet, "/", nil)
+	nonceCookie := extractCookie(getRec, "_csrf")
+	require.NotNil(t, nonceCookie)
+
+	form := url.Values{"csrf_token": {""}}
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(nonceCookie)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestUnmaskToken_ZeroLengthMaskedToken_Returns403 verifies that submitting a
+// zero-length string as the CSRF token (unmaskToken gets len==0) returns 403.
+func TestUnmaskToken_ZeroLengthMaskedToken_Returns403(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CSRFProtect(minimalCfg())(inner)
+
+	getRec := doRequest(t, handler, http.MethodGet, "/", nil)
+	nonceCookie := extractCookie(getRec, "_csrf")
+	require.NotNil(t, nonceCookie)
+
+	// A POST with just a cookie but no token field at all should be 403.
+	// This differs from the empty-header test: here no header or form field is set.
+	postRec := doRequest(t, handler, http.MethodPost, "/", func(r *http.Request) {
+		r.AddCookie(nonceCookie)
+	})
+	require.Equal(t, http.StatusForbidden, postRec.Code)
+}
+
+// TestUnmaskToken_TwoHexChars_Returns403 verifies that a very short but valid
+// hex token (e.g. "aabb" → pad=0xAA, masked=0xBB) is rejected because the
+// recovered HMAC won't match the expected 32-byte HMAC.
+func TestUnmaskToken_TwoHexChars_Returns403(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CSRFProtect(minimalCfg())(inner)
+
+	getRec := doRequest(t, handler, http.MethodGet, "/", nil)
+	nonceCookie := extractCookie(getRec, "_csrf")
+	require.NotNil(t, nonceCookie)
+
+	postRec := doRequest(t, handler, http.MethodPost, "/", func(r *http.Request) {
+		r.AddCookie(nonceCookie)
+		r.Header.Set("X-CSRF-Token", "aabb") // valid hex, wrong length for HMAC
+	})
+	require.Equal(t, http.StatusForbidden, postRec.Code)
+}
+
 // TestUnmaskToken_OddLengthReturns403 verifies that a submitted token with an
 // odd number of characters is rejected (unmaskToken returns nil for odd-length).
 func TestUnmaskToken_OddLengthReturns403(t *testing.T) {

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -288,6 +288,63 @@ func TestRateLimit_DifferentKeys_IndependentLimits(t *testing.T) {
 	require.Equal(t, http.StatusTooManyRequests, rec.Code)
 }
 
+// --- IPKey edge-case tests ---
+
+func TestIPKey_RemoteAddr_NoPort(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "192.168.1.1" // no port — net.SplitHostPort fails
+	require.Equal(t, "192.168.1.1", IPKey(req))
+}
+
+func TestIPKey_RemoteAddr_Empty(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = ""
+	require.Equal(t, "", IPKey(req))
+}
+
+func TestIPKey_RemoteAddr_IPv6_WithPort(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "[::1]:8080"
+	require.Equal(t, "::1", IPKey(req))
+}
+
+func TestIPKey_RemoteAddr_IPv6_NoPort(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "::1" // bare IPv6 — SplitHostPort fails
+	require.Equal(t, "::1", IPKey(req))
+}
+
+func TestIPKey_RemoteAddr_IPv6_Full(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "[2001:db8::1]:443"
+	require.Equal(t, "2001:db8::1", IPKey(req))
+}
+
+func TestIPKey_XForwardedFor_Empty(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "")
+	req.RemoteAddr = "10.0.0.1:1234"
+	// Empty header value — should fall through to RemoteAddr.
+	require.Equal(t, "10.0.0.1", IPKey(req))
+}
+
+func TestIPKey_XForwardedFor_Whitespace(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "  ,10.0.0.2")
+	req.RemoteAddr = "10.0.0.99:1234"
+	// First element after split is whitespace-only → trimmed to "".
+	// Since ip == "", the empty check triggers and falls through to
+	// X-Real-IP / RemoteAddr.
+	require.Equal(t, "10.0.0.99", IPKey(req))
+}
+
+func TestIPKey_XRealIP_Whitespace(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Real-IP", "  198.51.100.5  ")
+	req.RemoteAddr = "10.0.0.99:1234"
+	require.Equal(t, "198.51.100.5", IPKey(req))
+}
+
 // --- IPKey tests ---
 
 func TestIPKey_XForwardedFor(t *testing.T) {
@@ -593,5 +650,77 @@ func TestResetFailures_ClearsCounter(t *testing.T) {
 	req.RemoteAddr = "10.0.0.1:1234"
 	rec = httptest.NewRecorder()
 	handler2.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+}
+
+// TestBruteForceProtect_ImplicitOK_NoWriteHeader verifies that a handler which
+// writes a body without calling WriteHeader explicitly (Go implicitly sends 200)
+// does not count as a failure. The bruteForceWriter's WriteHeader is only called
+// when the handler (or Go's implicit flush) triggers it, so implicit 200 should
+// behave the same as an explicit 200.
+func TestBruteForceProtect_ImplicitOK_NoWriteHeader(t *testing.T) {
+	mw := BruteForceProtect(BruteForceConfig{
+		MaxAttempts: 1,
+		Cooldown:    time.Minute,
+	})
+	// Handler writes a body without calling WriteHeader — Go sends 200 implicitly.
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+	handler := mw(inner)
+
+	// Multiple requests should all succeed because implicit 200 is not a failure.
+	for range 5 {
+		req := httptest.NewRequest(http.MethodPost, "/login", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, "ok", rec.Body.String())
+	}
+}
+
+// TestBruteForceProtect_ImplicitOK_ThenFailure verifies that implicit 200
+// responses don't interfere with subsequent real failures being tracked.
+func TestBruteForceProtect_ImplicitOK_ThenFailure(t *testing.T) {
+	callCount := 0
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount <= 2 {
+			// First two calls: write body without explicit WriteHeader (implicit 200).
+			_, _ = w.Write([]byte("ok"))
+			return
+		}
+		// Subsequent calls: explicit 401.
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	mw := BruteForceProtect(BruteForceConfig{
+		MaxAttempts: 1,
+		Cooldown:    time.Minute,
+	})
+	handler := mw(inner)
+
+	// Two implicit-200 requests should not count as failures.
+	for range 2 {
+		req := httptest.NewRequest(http.MethodPost, "/login", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	// Third request returns 401 — counts as failure.
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// Fourth request should be blocked.
+	req = httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusTooManyRequests, rec.Code)
 }


### PR DESCRIPTION
## Summary
- Adds tests for `IPKey` edge cases: malformed `RemoteAddr` (no port, empty string, IPv6 with/without port), empty and whitespace-only `X-Forwarded-For`, whitespace-padded `X-Real-IP`
- Adds CSRF token handling edge cases: empty token in header and form field, zero-length masked token, short but valid hex token
- Adds brute force tests for handlers that write body without calling `WriteHeader` explicitly (Go's implicit 200), verifying implicit success doesn't count as failure

## Test plan
- [x] All new tests pass (`go test ./...`)
- [x] No existing tests broken

Closes #8