### PR TITLE
fix(wrappers): delegate http.Pusher on response writers

### DIFF
--- a/body.go
+++ b/body.go
@@ -72,6 +72,16 @@ func (m *maxBodyWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return nil, nil, fmt.Errorf("dorman: underlying ResponseWriter does not implement http.Hijacker")
 }
 
+// Push delegates to the underlying ResponseWriter if it implements [http.Pusher].
+// When the underlying writer does not support HTTP/2 server push, it returns
+// [http.ErrNotSupported] to match the standard library pattern.
+func (m *maxBodyWriter) Push(target string, opts *http.PushOptions) error {
+	if p, ok := m.ResponseWriter.(http.Pusher); ok {
+		return p.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}
+
 // MaxRequestBody returns middleware that limits request body size using
 // [http.MaxBytesReader]. Each request's body is wrapped so that reading
 // beyond the allowed number of bytes returns an error and closes the reader.

--- a/body_test.go
+++ b/body_test.go
@@ -46,6 +46,23 @@ func TestMaxBodyWriter_Hijack_ErrorWhenNotSupported(t *testing.T) {
 	require.Contains(t, err.Error(), "http.Hijacker")
 }
 
+func TestMaxBodyWriter_Push_Delegates(t *testing.T) {
+	inner := &pusherRecorder{ResponseWriter: httptest.NewRecorder()}
+	w := &maxBodyWriter{ResponseWriter: inner}
+	opts := &http.PushOptions{Method: http.MethodGet}
+	err := w.Push("/assets/app.js", opts)
+	require.NoError(t, err)
+	require.Equal(t, "/assets/app.js", inner.pushTarget)
+	require.Same(t, opts, inner.pushOpts)
+}
+
+func TestMaxBodyWriter_Push_ErrorWhenNotSupported(t *testing.T) {
+	inner := newPlainResponseWriter()
+	w := &maxBodyWriter{ResponseWriter: inner}
+	err := w.Push("/x", nil)
+	require.ErrorIs(t, err, http.ErrNotSupported)
+}
+
 func TestMaxBodyWriter_InterfacePreservation_ThroughMiddleware(t *testing.T) {
 	inner := &flusherHijackerRecorder{ResponseWriter: httptest.NewRecorder()}
 

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -410,6 +410,16 @@ func (bw *bruteForceWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return nil, nil, fmt.Errorf("dorman: underlying ResponseWriter does not implement http.Hijacker")
 }
 
+// Push delegates to the underlying ResponseWriter if it implements [http.Pusher].
+// When the underlying writer does not support HTTP/2 server push, it returns
+// [http.ErrNotSupported] to match the standard library pattern.
+func (bw *bruteForceWriter) Push(target string, opts *http.PushOptions) error {
+	if p, ok := bw.ResponseWriter.(http.Pusher); ok {
+		return p.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}
+
 // BruteForceProtect returns middleware that tracks failed response status codes
 // and blocks a key after it exceeds MaxAttempts failures. The downstream
 // handler's response status is inspected via a wrapped ResponseWriter. Once

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -45,6 +45,23 @@ func TestBruteForceWriter_Hijack_ErrorWhenNotSupported(t *testing.T) {
 	require.Contains(t, err.Error(), "http.Hijacker")
 }
 
+func TestBruteForceWriter_Push_Delegates(t *testing.T) {
+	inner := &pusherRecorder{ResponseWriter: httptest.NewRecorder()}
+	w := &bruteForceWriter{ResponseWriter: inner}
+	opts := &http.PushOptions{Method: http.MethodGet}
+	err := w.Push("/assets/app.js", opts)
+	require.NoError(t, err)
+	require.Equal(t, "/assets/app.js", inner.pushTarget)
+	require.Same(t, opts, inner.pushOpts)
+}
+
+func TestBruteForceWriter_Push_ErrorWhenNotSupported(t *testing.T) {
+	inner := newPlainResponseWriter()
+	w := &bruteForceWriter{ResponseWriter: inner}
+	err := w.Push("/x", nil)
+	require.ErrorIs(t, err, http.ErrNotSupported)
+}
+
 func TestBruteForceWriter_InterfacePreservation_ThroughMiddleware(t *testing.T) {
 	inner := &flusherHijackerRecorder{ResponseWriter: httptest.NewRecorder()}
 

--- a/responsewriter_test.go
+++ b/responsewriter_test.go
@@ -23,6 +23,21 @@ func (f *flusherHijackerRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) 
 	return nil, nil, nil
 }
 
+// pusherRecorder is an httptest.ResponseRecorder-like type that also
+// implements http.Pusher for testing Push delegation.
+type pusherRecorder struct {
+	http.ResponseWriter
+	pushTarget string
+	pushOpts   *http.PushOptions
+	pushErr    error
+}
+
+func (p *pusherRecorder) Push(target string, opts *http.PushOptions) error {
+	p.pushTarget = target
+	p.pushOpts = opts
+	return p.pushErr
+}
+
 // plainResponseWriter is a minimal ResponseWriter that does NOT implement
 // http.Flusher or http.Hijacker. Used to test that delegation gracefully
 // handles missing optional interfaces.


### PR DESCRIPTION
## Summary
- Add `Push(target, opts)` delegation to `bruteForceWriter` and `maxBodyWriter`. When the underlying writer implements `http.Pusher`, the call is forwarded; otherwise it returns `http.ErrNotSupported` matching the standard library pattern.
- Extend the shared response-writer test helpers with a `pusherRecorder` and cover supported and unsupported cases for both wrappers.

The README already documented `http.Pusher` preservation; this brings the code in line with the contract.

Closes #48

## Test plan
- [x] `go test ./...`