### PR TITLE
feat(csrf): expose CSRF failure reason via context accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,14 +553,21 @@ Dorman exports sentinel errors for programmatic error handling:
 | `ErrCSRFTokenMissing` | No token in header or form field   |
 | `ErrCSRFTokenInvalid` | Token does not match expected HMAC |
 
-Use `errors.Is` to match:
+Use `dorman.CSRFError(r)` from inside a custom `ErrorHandler` and match with
+`errors.Is`:
 
 ```go
 csrf := dorman.CSRFProtect(dorman.CSRFConfig{
 	Key: secret,
 	ErrorHandler: func(w http.ResponseWriter, r *http.Request) {
-		// The CSRF error is available via the request context's error
-		http.Error(w, "CSRF validation failed", http.StatusForbidden)
+		switch {
+		case errors.Is(dorman.CSRFError(r), dorman.ErrCSRFTokenMissing):
+			http.Error(w, "CSRF token missing", http.StatusForbidden)
+		case errors.Is(dorman.CSRFError(r), dorman.ErrCSRFTokenInvalid):
+			http.Error(w, "CSRF token invalid", http.StatusForbidden)
+		default:
+			http.Error(w, "CSRF validation failed", http.StatusForbidden)
+		}
 	},
 })
 ```

--- a/csrf.go
+++ b/csrf.go
@@ -21,6 +21,10 @@ type csrfTokenKeyType struct{}
 
 var csrfTokenCtxKey csrfTokenKeyType
 
+type csrfErrorKeyType struct{}
+
+var csrfErrorCtxKey csrfErrorKeyType
+
 // csrfMasker is stored on the context; it holds the raw HMAC bytes and the
 // maskToken function so that GetToken can apply a fresh pad on every call.
 type csrfMasker struct {
@@ -175,7 +179,13 @@ func CSRFProtect(cfg CSRFConfig) func(http.Handler) http.Handler {
 		return token
 	}
 
-	fail := func(w http.ResponseWriter, r *http.Request) {
+	// fail writes the CSRF rejection response. When cause is non-nil, it is
+	// attached to the request context so that the configured ErrorHandler can
+	// retrieve it via [CSRFError].
+	fail := func(w http.ResponseWriter, r *http.Request, cause error) {
+		if cause != nil {
+			r = r.WithContext(context.WithValue(r.Context(), csrfErrorCtxKey, cause))
+		}
 		if cfg.ErrorHandler != nil {
 			cfg.ErrorHandler(w, r)
 			return
@@ -279,14 +289,17 @@ func CSRFProtect(cfg CSRFConfig) func(http.Handler) http.Handler {
 			} else {
 				// Unsafe method: validate Origin header if configured.
 				if cfg.ValidateOrigin && !checkOrigin(r) {
-					fail(w, r)
+					// Origin-check failures intentionally leave the cause unset:
+					// there is no exported sentinel for origin-check failures
+					// and inventing one is out of scope for #47.
+					fail(w, r, nil)
 					return
 				}
 
 				// Unsafe method: must have existing cookie nonce.
 				c, err := r.Cookie(cfg.CookieName)
 				if err != nil || c.Value == "" {
-					fail(w, r)
+					fail(w, r, ErrCSRFTokenMissing)
 					return
 				}
 				nonce = c.Value
@@ -299,21 +312,21 @@ func CSRFProtect(cfg CSRFConfig) func(http.Handler) http.Handler {
 					}
 				}
 				if submitted == "" {
-					fail(w, r)
+					fail(w, r, ErrCSRFTokenMissing)
 					return
 				}
 
 				// Unmask the submitted token to recover the real HMAC bytes.
 				recoveredBytes := unmaskToken(submitted)
 				if recoveredBytes == nil {
-					fail(w, r)
+					fail(w, r, ErrCSRFTokenInvalid)
 					return
 				}
 
 				// Recompute expected HMAC and compare.
 				expected := computeHMAC(nonce)
 				if !hmac.Equal(recoveredBytes, expected) {
-					fail(w, r)
+					fail(w, r, ErrCSRFTokenInvalid)
 					return
 				}
 
@@ -366,4 +379,15 @@ func GetToken(r *http.Request) string {
 		return ""
 	}
 	return tok
+}
+
+// CSRFError returns the CSRF failure cause attached to the request context by
+// [CSRFProtect] before it invokes [CSRFConfig.ErrorHandler]. It returns nil
+// when no cause has been recorded (for example outside of an error handler,
+// or when the failure was an origin-check rejection). Callers can use
+// [errors.Is] to distinguish between [ErrCSRFTokenMissing] and
+// [ErrCSRFTokenInvalid].
+func CSRFError(r *http.Request) error {
+	err, _ := r.Context().Value(csrfErrorCtxKey).(error)
+	return err
 }

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -1,6 +1,7 @@
 package dorman
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -283,6 +284,129 @@ func TestCustomErrorHandler_CalledOnFailure(t *testing.T) {
 	rec := doRequest(t, handler, http.MethodPost, "/", nil)
 	require.True(t, errorHandlerCalled)
 	require.Equal(t, http.StatusTeapot, rec.Code)
+}
+
+// TestCSRFError_NilOutsideErrorHandler verifies that CSRFError returns nil when
+// no cause has been recorded on the request context.
+func TestCSRFError_NilOutsideErrorHandler(t *testing.T) {
+	var captured error
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = CSRFError(r)
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CSRFProtect(minimalCfg())(inner)
+
+	rec := doRequest(t, handler, http.MethodGet, "/", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, captured)
+}
+
+// TestCSRFError_MissingToken_ReportsSentinel verifies that a POST with no
+// submitted token reports ErrCSRFTokenMissing through CSRFError.
+func TestCSRFError_MissingToken_ReportsSentinel(t *testing.T) {
+	// First acquire a cookie via GET so we have an existing nonce.
+	getHandler := CSRFProtect(minimalCfg())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	getRec := doRequest(t, getHandler, http.MethodGet, "/", nil)
+	nonceCookie := extractCookie(getRec, "_csrf")
+	require.NotNil(t, nonceCookie)
+
+	var captured error
+	cfg := minimalCfg()
+	cfg.ErrorHandler = func(w http.ResponseWriter, r *http.Request) {
+		captured = CSRFError(r)
+		http.Error(w, "", http.StatusForbidden)
+	}
+	handler := CSRFProtect(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// POST with cookie but no token.
+	rec := doRequest(t, handler, http.MethodPost, "/", func(r *http.Request) {
+		r.AddCookie(nonceCookie)
+	})
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Error(t, captured)
+	require.True(t, errors.Is(captured, ErrCSRFTokenMissing), "expected ErrCSRFTokenMissing, got %v", captured)
+}
+
+// TestCSRFError_MissingCookie_ReportsMissing verifies that a POST without the
+// CSRF cookie reports ErrCSRFTokenMissing.
+func TestCSRFError_MissingCookie_ReportsMissing(t *testing.T) {
+	var captured error
+	cfg := minimalCfg()
+	cfg.ErrorHandler = func(w http.ResponseWriter, r *http.Request) {
+		captured = CSRFError(r)
+		http.Error(w, "", http.StatusForbidden)
+	}
+	handler := CSRFProtect(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := doRequest(t, handler, http.MethodPost, "/", nil)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.True(t, errors.Is(captured, ErrCSRFTokenMissing), "expected ErrCSRFTokenMissing, got %v", captured)
+}
+
+// TestCSRFError_MalformedToken_ReportsInvalid verifies that a malformed
+// submitted token reports ErrCSRFTokenInvalid.
+func TestCSRFError_MalformedToken_ReportsInvalid(t *testing.T) {
+	getHandler := CSRFProtect(minimalCfg())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	getRec := doRequest(t, getHandler, http.MethodGet, "/", nil)
+	nonceCookie := extractCookie(getRec, "_csrf")
+	require.NotNil(t, nonceCookie)
+
+	var captured error
+	cfg := minimalCfg()
+	cfg.ErrorHandler = func(w http.ResponseWriter, r *http.Request) {
+		captured = CSRFError(r)
+		http.Error(w, "", http.StatusForbidden)
+	}
+	handler := CSRFProtect(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Malformed token (odd length, not hex) — unmaskToken returns nil.
+	rec := doRequest(t, handler, http.MethodPost, "/", func(r *http.Request) {
+		r.AddCookie(nonceCookie)
+		r.Header.Set("X-CSRF-Token", "not-hex-odd")
+	})
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.True(t, errors.Is(captured, ErrCSRFTokenInvalid), "expected ErrCSRFTokenInvalid, got %v", captured)
+}
+
+// TestCSRFError_MismatchedToken_ReportsInvalid verifies that a well-formed but
+// mismatched token reports ErrCSRFTokenInvalid.
+func TestCSRFError_MismatchedToken_ReportsInvalid(t *testing.T) {
+	getHandler := CSRFProtect(minimalCfg())(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	getRec := doRequest(t, getHandler, http.MethodGet, "/", nil)
+	nonceCookie := extractCookie(getRec, "_csrf")
+	require.NotNil(t, nonceCookie)
+
+	var captured error
+	cfg := minimalCfg()
+	cfg.ErrorHandler = func(w http.ResponseWriter, r *http.Request) {
+		captured = CSRFError(r)
+		http.Error(w, "", http.StatusForbidden)
+	}
+	handler := CSRFProtect(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Well-formed masked token (128 hex chars = 64 bytes pad+masked) that
+	// decodes successfully but does not match the cookie's HMAC.
+	bogus := strings.Repeat("ab", 64)
+	rec := doRequest(t, handler, http.MethodPost, "/", func(r *http.Request) {
+		r.AddCookie(nonceCookie)
+		r.Header.Set("X-CSRF-Token", bogus)
+	})
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.True(t, errors.Is(captured, ErrCSRFTokenInvalid), "expected ErrCSRFTokenInvalid, got %v", captured)
 }
 
 // TestSafeMethods_HeadAndOptions verifies that HEAD and OPTIONS do not reject.


### PR DESCRIPTION
## Summary
- Add a public `CSRFError(r *http.Request) error` accessor so custom `ErrorHandler` implementations can distinguish failure causes with `errors.Is`.
- Thread an optional cause through the internal `fail` helper:
  - Missing cookie or missing submitted token -> `ErrCSRFTokenMissing`
  - Malformed or HMAC-mismatched submitted token -> `ErrCSRFTokenInvalid`
  - Origin-check failures leave the cause unset (no sentinel exists for them)
- Update the README example to show `dorman.CSRFError(r)` with `errors.Is` matching.
- Add tests covering missing-cookie, missing-token, malformed-token, mismatched-token, and nil-outside-handler cases.

The exported sentinels were previously undiscoverable; this gives them a real runtime contract.

Closes #47

## Test plan
- [x] `go test ./...`